### PR TITLE
Make message optional

### DIFF
--- a/dist/CookieDisclaimer.js
+++ b/dist/CookieDisclaimer.js
@@ -225,8 +225,8 @@
           // 2. Prepend to the body
           document.body.insertBefore(el, document.body.firstChild);
 
-          // 3. Add message
-          document.getElementById('message').innerHTML = settings.message;
+          // 3. Add message if present
+          if (settings.message) document.getElementById('message').innerHTML = settings.message;
 
           // 4. Add class to body
           if (document.body.classList) document.body.classList.add(bodyClass);else if (!hasClass(document.body, bodyClass)) document.body.className += ' ' + bodyClass;


### PR DESCRIPTION
Thank you for a nice little package 👍 

I integrated this to our website today and found that the `message` option wasn't optional ([see code](https://github.com/jonnyhaynes/cookie-disclaimer/blob/master/src/CookieDisclaimer.js#L202)). Our site is translated and I therefore provide multiple versions of the cookie-template (`/ar/about-cookies` etc..).

For reference, our init code looks something like this:

``` js
var body = document.getElementsByTagName('body')[0];
var locale = body.getAttribute('data-lang');

var templateName = 'cookie-banner';
// en locale has no path prefix
if (locale !== 'en') {
  templateName = '/' + locale + '/' + templateName;
}

CookieDisclaimer.init({
  name: 'CookieAccept',
  message: '',
  template: templateName
});
```

In our template I had to add `<div id="message"></div>`, otherwise an error would be thrown `Uncaught TypeError: Cannot read property 'innerHTML' of null`.

---

If you accept this we, and potentially others, can set the `message` option to `false` _and_ remove the "dummy message div".

``` js
CookieDisclaimer.init({
  name: 'CookieAccept',
  message: false,
  template: templateName
});
```
